### PR TITLE
chore(ci): don't build nvidia images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_flavor: [-main, -nvidia]
+        image_flavor: [-main]
         base_name: [framework]
         base_image_name: [silverblue, kinoite, vauxite, sericea, base, lxqt, mate, bazzite, bazzite-gnome, bluefin, bluefin-dx]
         major_version: [38]


### PR DESCRIPTION
Frameworks don't come with nvidia, I guess for eGPUs but imo not worth it, at least for now while we're builder starved.