### PR TITLE
feat(ci): Verify base image with cosign before building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,12 +58,17 @@ jobs:
           - base_image_name: onyx
             major_version: 38
     steps:
-      - name: Maximize build space
-        uses: ublue-os/remove-unwanted-software@v6
-
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
         uses: actions/checkout@v3
+
+      - name: Verify base image
+        uses: EyeCantCU/cosign-action/verify@v0.2.1
+        with:
+          containers: ${{ matrix.base_image_name }}${{ matrix.image_flavor }}:${{ matrix.major_version }}
+
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@v6
 
       - name: Check just syntax
         uses: ublue-os/just-action@v1


### PR DESCRIPTION
Validate the integrity of base image being built from via cosign before continuing to build. Ensures we only build from signed images